### PR TITLE
fix banner_scale issue with freezing/token garbaging

### DIFF
--- a/BootMaster/config.c
+++ b/BootMaster/config.c
@@ -3189,7 +3189,7 @@ VOID ReadConfig (
             }
             #endif
 
-            Flag = TokenList[i];
+            Flag = TokenList[1];
             if (MyStriCmp (Flag, L"noscale")) {
                 GlobalConfig.BannerScale = BANNER_NOSCALE;
             }


### PR DESCRIPTION
This change fixes an issue when banner_scale is active:
- in the config.conf file: caused freeze
- - in the included theme file: caused warning and garbage in the log